### PR TITLE
Use String.uncapitalize_ascii instead of String.uncapitalize

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 Requirements:
 -------------
-  OCaml (reasonably recent version; I use version 4.01.0)
-  OCamlgraph (reasonably recent version; I use version 1.8.3)
+  OCaml (reasonably recent version; I use version 4.03.0)
+  OCamlgraph (reasonably recent version; I use version 1.8.7)
   One or more of the following SMT-solvers:
     yices, yices2, z3, cvc4, mathsat5
   Optionally:

--- a/terms/cint_aux.ml
+++ b/terms/cint_aux.ml
@@ -152,7 +152,7 @@ and getCand v =
     else if v.[0] = '_' then
       "underscore" ^ rest
     else
-      String.uncapitalize v
+      String.uncapitalize_ascii v
 and attachPrimes cand used =
   if (Utils.contains used cand) then
     attachPrimes (cand ^ "'") used


### PR DESCRIPTION
Compilation failed since `String.uncapitalize` is deprecated after OCaml 4.03.0. The details are described in [release notes of OCaml 4.03.0](http://caml.inria.fr/pub/distrib/ocaml-4.03/notes/Changes).

This PR simply changes `String.uncapitalize` to `String.uncapitalize_ascii`.

----

The error message:

```
File "terms/cint_aux.ml", line 155, characters 6-25:
Warning 3: deprecated: String.uncapitalize
Use String.uncapitalize_ascii instead.
File "terms/cint_aux.ml", line 1:
Error: Some fatal warnings were triggered (1 occurrences)
Command exited with code 2.
Compilation unsuccessful after building 68 targets (66 cached) in 00:00:00.
```